### PR TITLE
Setup CI workflow parsing all .logic files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  syntax-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get the CI tool
+        uses: robinraju/release-downloader@v1
+        with:
+          repository: Ibot02/tmcr-newlogic-ci
+          tag: "v1.0"
+          filename: "tmcr-newlogic-ci"
+          tarBall: false
+          zipBall: false
+
+      - name: Make it executable
+        run: chmod +x "$GITHUB_WORKSPACE/tmcr-newlogic-ci"
+
+      - name: Run the CI tool
+        run: |
+          cd $GITHUB_WORKSPACE
+          ./tmcr-newlogic-ci *.logic


### PR DESCRIPTION
I know this workflow is failing, but that's because of issues in current master.

We could fork the tmcr-newlogic-ci repo under the minishmaker group and have it use a release from there instead, to avoid depending on my repo for this.